### PR TITLE
Change to a specific commit for the neon repo that works

### DIFF
--- a/docker/neon-proxy/Dockerfile
+++ b/docker/neon-proxy/Dockerfile
@@ -15,8 +15,9 @@ RUN \
 
 # get and build the proxy
 RUN git clone https://github.com/neondatabase/neon.git
+RUN cd neon && git checkout 3710c32
 WORKDIR /neon
-RUN cargo build --bin proxy
+RUN cargo build --bin proxy --features "testing"
 
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
At some point in the last two months, one of the releases in the neon repo broke the way this solution works. Seeing as this seems to be the only way to work around developing using a neon database locally, this creates an issue for anyone using it.

This PR adds a line to the dockerfile to checkout the specific release from Nov 9 where this worked. It is possible that there is a more recent release after Nov 9 where it would also work, however it seems irrelevant given the scope of this issue and that it would run the same in prod either way.

Note: While trying the latest release of neon, It seems that you need to build the proxy using the `--features "testing"` flag to be able to run it with `--auth-backend` as postgres.