### PR TITLE
Make sure postgres is ready to accept connections before neon-proxy starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=main
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   neon-proxy:
     image: ghcr.io/timowilhelm/local-neon-http-proxy:main
@@ -34,7 +39,8 @@ services:
     ports:
       - '4444:4444'
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
 volumes:
   db_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,11 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=main
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   neon-proxy:
     build:
@@ -22,7 +27,8 @@ services:
     ports:
       - '4444:4444'
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
 volumes:
   db_data:


### PR DESCRIPTION
I found an issue where it is possible to have both containers running without the ﻿`neon_control_plane` schema being created. It's a race condition that is very likely to happen when running `docker compose up` for the first time.

## how to reproduce
- to be on a clean slate, run `docker compose down --volumes` to remove the containers and get rid of the db volume
- run `docker-compose up` to start everything
- `neon-proxy-1` was not able to create the schema. The logs show that the DB was not initialized at this point even though the Postgres service was started.
```shell
...
postgres-1    | creating configuration files ... ok
neon-proxy-1  | psql: error: connection to server at "postgres" (192.168.96.2), port 5432 failed: Connection refused
neon-proxy-1  | 	Is the server running on that host and accepting TCP/IP connections?
...
postgres-1    | PostgreSQL init process complete; ready for start up.
...
``` 
- both containers are running now, but the DB has no `neon_control_plane` schema
- press CTRL+C to stop the containers
- run `docker-compose up` to start the containers again
- this time the DB inits faster and it is very likely that the schema will be created

## solution

Instead of only waiting for Postgres container to be running, ~ChatGPT~ I added a health check that can be used in the ﻿`depends_on` block of the ﻿`neon-proxy` service to guarantee that the DB can be used already.

Now the logs indicate that the DB is used after its initialization.

```shell
postgres-1    | PostgreSQL init process complete; ready for start up.
...
neon-proxy-1  | CREATE SCHEMA
...
neon-proxy-1  | CREATE TABLE
``` 